### PR TITLE
Fix Show in Imgur link

### DIFF
--- a/src/feature/catalog/ShipInfo/ShipInfoTabs.tsx
+++ b/src/feature/catalog/ShipInfo/ShipInfoTabs.tsx
@@ -52,7 +52,7 @@ export const ShipInfoTabs = ({ ...props }: ShipInfoTabsProps) => {
               style={{ position: 'relative' }}
               width='1024'
             />
-            <Text fontSize='sm' mt='2' textAlign='right'>
+            <Text fontSize='sm' mt='2' position='relative' textAlign='right'>
               Show in{' '}
               <Link
                 color='blue.400'


### PR DESCRIPTION
Make "Imgur" link active. Was not clickable in latest Chrome